### PR TITLE
Ensure that template's path values are not undefined

### DIFF
--- a/broccoli-angular-templates-cache.js
+++ b/broccoli-angular-templates-cache.js
@@ -87,14 +87,15 @@ BroccoliAngularTemplateCache.prototype.updateCache = function(srcDir, destDir) {
 			prepend = self.options.prepend || false,
 			strip = self.options.strip || false,
 			moduleName = self.options.moduleName,
-			firstFile = null;
+			firstFile = null,
+			filePath;
 
-			_.each(files,function(file){
+			_.each(files, function(file){
 				if(self.options.absolute){
 					filePath = file.replace(path.dirname(srcDir[0])+'/','');
 				}
 				templates.push({
-					path: filePath,
+					path: filePath || file,
 					content: fs.readFileSync(file).toString('utf-8')
 				});
 			});


### PR DESCRIPTION
I was getting an error because filePath was _undefined_, and this patch prevents that from occuring. I didn't work out the full logic of what was going on, I just fixed the issue in a way that seemed correct.

Basically though, _filePath_ can be undefined in the `templates.push` call, and by initializing the variable and providing for an alternative value, the code will not encounter an error because _filePath_ is not defined and the process with not be wrong as having _filePath_ default to _file_ fulfills the requirements of that anonymous function.
