### PR TITLE
Don't compile invalid templates, throw an exception

### DIFF
--- a/broccoli-angular-templates-cache.js
+++ b/broccoli-angular-templates-cache.js
@@ -46,8 +46,7 @@ function transformTemplateEntry(entry, strip, prepend, minify) {
 			content = htmlMin(content, minify);
 		} catch (e) {
 			parseError = String(e);
-			content = '<h1>Invalid template: ' + entry.path + '</h1>' +
-			'<pre>' + escapeTags(parseError) + '</pre>';
+			throw new Error(parseError, entry.path);
 		}
 	}
 	content = escapeHtmlContent(content);


### PR DESCRIPTION
If you have an invalid HTML template, minification will result in a template with the content "Invalid template: ..."

Instead of failing silently and hoping you find the error'd template, this PR makes it so the build throws an exception.
